### PR TITLE
ci: ignore engines restrictions on yarn install

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -15,7 +15,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install Yarn dependencies
-        run: yarn --immutable
+        run: yarn --immutable --ignore-engines
 
   build:
     name: Build
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn lint
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
@@ -88,7 +88,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn test
       - name: Require clean working directory
         shell: bash


### PR DESCRIPTION
@metamask/eslint-config@10 is not compatible with Node.js v12. This change and its addition of the `--ignore-engines` flag can be removed once Node.js v12 support has been dropped.

https://github.com/MetaMask/nonce-tracker/actions/runs/6154683000/job/16700412405