### PR TITLE
Lint fixes

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -49,7 +49,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -15,7 +15,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install Yarn dependencies
-        run: yarn --immutable
+        run: yarn --immutable --ignore-engines
 
   build:
     name: Build
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn lint
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
@@ -88,7 +88,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn test
       - name: Require clean working directory
         shell: bash

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -59,12 +59,13 @@ jobs:
           cache: 'yarn'
       - run: yarn --immutable --immutable-cache --ignore-engines
       - run: yarn lint
-      - name: Validate RC changelog
-        if: ${{ startsWith(github.head_ref, 'release/') }}
-        run: yarn auto-changelog validate --rc
-      - name: Validate changelog
-        if: ${{ !startsWith(github.head_ref, 'release/') }}
-        run: yarn auto-changelog validate
+      # TODO: Enable once CHANGELOG.md is in place
+      #- name: Validate RC changelog
+      #  if: ${{ startsWith(github.head_ref, 'release/') }}
+      #  run: yarn auto-changelog validate --rc
+      #- name: Validate changelog
+      #  if: ${{ !startsWith(github.head_ref, 'release/') }}
+      #  run: yarn auto-changelog validate
       - name: Require clean working directory
         shell: bash
         run: |

--- a/test/nonce-tracker-test.js
+++ b/test/nonce-tracker-test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+// eslint-disable-next-line import/no-unresolved
 const NonceTracker = require('../dist');
 const MockTxGen = require('./lib/mock-tx-gen');
 


### PR DESCRIPTION
## Description

Contains the following linting-related fixes:
- ci: Skip linting job in nodejs v12, v14
- ci: add `--ignore-engines` to `yarn [install]` invocations
  - some devDeps depend on nodejs v14. This change can be reverted once nodejs v12 support has been dropped.
- lint(test): ignore `import/no-unresolved`  violation by importing `dist`
  - When trying locally, this reproduces consistently back to #22. Not sure why results differ from CircleCI, considering lockfile.
- ci: disable linting of non-existing `CHANGELOG.md`
  - #40 